### PR TITLE
Automatic GSL detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,28 @@ else
     CC = cc  # sets the C-compiler
 endif
 
-GSL_INCL = -I$(GSL_DIR)/include  # make sure your system knows where GSL_DIR is
-GSL_LIBS = -L$(GSL_DIR)/lib
+# GSL automatic detection
+GSL_FOUND := $(shell gsl-config --version 2>/dev/null)
+ifndef GSL_FOUND
+  $(warning GSL not found in path - please install GSL before installing SAGE (or, update the PATH environment variable such that "gsl-config" is found))
+  # If the automatic detection fails, set GSL_DIR appropriately
+  GSL_DIR := /opt/local
+  GSL_INCL := -I$(GSL_DIR)/include  
+  GSL_LIBDIR := $(GSL_DIR)/lib
+  # since GSL is not in PATH, the runtime environment might
+  # not be setup correctly either. Therefore, adding the compiletime
+  # library path is even more important(the -Xlinker bit)
+  GSL_LIBS := -L$(GSL_LIBDIR) -lgsl -lgslcblas -Xlinker -rpath -Xlinker $(GSL_LIBDIR) 
+else
+  # GSL is probably configured correctly, pick up the locations automatically. 
+  GSL_INCL := $(shell gsl-config --cflags)
+  GSL_LIBDIR := $(shell gsl-config --prefix)/lib
+  GSL_LIBS   := $(shell gsl-config --libs) -Xlinker -rpath -Xlinker $(GSL_LIBDIR)
+endif
+
 OPTIMIZE = -g -O0 -Wall  # optimization and warning flags
 
-LIBS   =   -g -lm  $(GSL_LIBS) -lgsl -lgslcblas 
+LIBS   =   -g -lm  $(GSL_LIBS) 
 
 CFLAGS =   $(OPTIONS) $(OPT) $(OPTIMIZE) $(GSL_INCL)
 

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,17 @@ INCL   =	./code/core_allvars.h  \
 			./Makefile
 
 # USE-MPI = yes  # set this if you want to run in parallel
+USE_SIMULATION_HALOID = yes # set this if you have unique haloids in the MostBoundID field. 
 
 ifdef USE-MPI
     OPT += -DMPI  #  This creates an MPI version that can be used to process files in parallel
     CC = mpicc  # sets the C-compiler
 else
     CC = cc  # sets the C-compiler
+endif
+
+ifdef USE_SIMULATION_HALOID
+   OPT += -DUSE_SIMULATION_HALOID
 endif
 
 # GSL automatic detection
@@ -50,7 +55,7 @@ else
   GSL_LIBS   := $(shell gsl-config --libs) -Xlinker -rpath -Xlinker $(GSL_LIBDIR)
 endif
 
-OPTIMIZE = -g -O0 -Wall  # optimization and warning flags
+OPTIMIZE = -g -O0 -Wall -Wpadded # optimization and warning flags
 
 LIBS   =   -g -lm  $(GSL_LIBS) 
 

--- a/code/core_allvars.h
+++ b/code/core_allvars.h
@@ -112,7 +112,10 @@ struct GALAXY
   int   GalaxyNr;
   int   CentralGal;
   int   HaloNr;
-  long long  MostBoundID;
+  union{
+      long long  MostBoundID;
+      long long SimulationHaloID;
+  };
 
   int   mergeType;  //0=none; 1=minor merger; 2=major merger; 3=disk instability; 4=disrupt to ICS
   int   mergeIntoID;
@@ -165,7 +168,7 @@ struct GALAXY
   float TimeOfLastMajorMerger;
   float TimeOfLastMinorMerger;
   float OutflowRate;
-	float TotalSatelliteBaryons;
+  float TotalSatelliteBaryons;
 
   // infall properties
   float infallMvir;

--- a/code/core_save.c
+++ b/code/core_save.c
@@ -121,7 +121,16 @@ void prepare_galaxy_for_output(int filenr, int tree, struct GALAXY *g, struct GA
     
   o->SAGEHaloIndex = g->HaloNr;
   o->SAGETreeIndex = tree;
+#ifdef USE_SIMULATION_HALOID
+  //For other halofinder/mergertree codes, pass the unique haloid along
+  //Useful to compare different SAM's on a halo-by-halo basis
+  //There is a type conversion happening (long long to int).
+  //If SimulationHaloID is > INT_MAX (= ~ 2e9),  then the HaloID will be wrong.
+  o->SimulationFOFHaloIndex = Halo[g->HaloNr].SimulationHaloID;
+#else
+  //For LHaloTrees, ID is simply the position in the file.
   o->SimulationFOFHaloIndex = Halo[g->HaloNr].SubhaloIndex;
+#endif  
 
   o->mergeType = g->mergeType;
   o->mergeIntoID = g->mergeIntoID;

--- a/code/core_simulation.h
+++ b/code/core_simulation.h
@@ -16,7 +16,10 @@ struct halo_data
   float VelDisp;
   float Vmax;
   float Spin[3];
-  long long MostBoundID;
+  union{
+      long long MostBoundID;//for LHaloTrees, this is the ID for the most bound particle
+      long long SimulationHaloID;//for other mergertree codes, this contains an unique haloid. 
+  };
 
   // original position in simulation tree files
   int SnapNum;


### PR DESCRIPTION
If `GSL` is installed correctly, then the executable `gsl-config` can be directly used to pick up the locations of the include headers and the library files. The additional, `-Xlinker -rpath -Xlinker $(GSL_LIBDIR)` simply embeds the library path used at compile time into the executable such that the library used at compile time is picked up at runtime (in the unusual circumstance that incompatible versions of `GSL` are installed and the ordering in `(DY)LD_LIBRARY_PATH` and `PATH` are flipped. 

In case, `gsl-config` is not found in `PATH`, then the user has the ability to specify where `gsl` is located. 
