### PR TITLE
Fofmaxgals patch

### DIFF
--- a/code/core_allvars.c
+++ b/code/core_allvars.c
@@ -90,7 +90,7 @@ int ListOutputSnaps[ABSOLUTEMAXSNAPS];
 
 double ZZ[ABSOLUTEMAXSNAPS];
 double AA[ABSOLUTEMAXSNAPS];
-double Age[ABSOLUTEMAXSNAPS];
+double *Age;
 
 int MAXSNAPS;
 int NOUT;

--- a/code/core_allvars.h
+++ b/code/core_allvars.h
@@ -267,7 +267,7 @@ extern int    ListOutputSnaps[ABSOLUTEMAXSNAPS];
 
 extern double ZZ[ABSOLUTEMAXSNAPS];
 extern double AA[ABSOLUTEMAXSNAPS];
-extern double Age[ABSOLUTEMAXSNAPS];
+extern double *Age;
 
 extern int    MAXSNAPS;
 extern int    NOUT;

--- a/code/core_build_model.c
+++ b/code/core_build_model.c
@@ -112,7 +112,12 @@ int join_galaxies_of_progenitors(int halonr, int ngalstart)
   {
     for(i = 0; i < HaloAux[prog].NGalaxies; i++)
     {
-			assert(ngal < FoF_MaxGals);
+        if(ngal == (FoF_MaxGals-1)) {
+            FoF_MaxGals += 10000;
+            Gal = myrealloc(Gal, FoF_MaxGals * sizeof(struct GALAXY));
+        }
+        assert(ngal < FoF_MaxGals);
+            
 
       // This is the cruical line in which the properties of the progenitor galaxies 
       // are copied over (as a whole) to the (temporary) galaxies Gal[xxx] in the current snapshot 

--- a/code/core_init.c
+++ b/code/core_init.c
@@ -19,6 +19,8 @@ void init(void)
 {
   int i;
 
+  Age = mymalloc(ABSOLUTEMAXSNAPS*sizeof(*Age));
+  
   random_generator = gsl_rng_alloc(gsl_rng_ranlxd1);
   gsl_rng_set(random_generator, 42);	 // start-up seed 
 
@@ -27,6 +29,11 @@ void init(void)
 
   read_snap_list();
 
+  //Hack to fix deltaT for snapshot 0
+  //This way, galsnapnum = -1 will not segfault.
+  Age[0] = time_to_present(1000.0);//lookback time from z=1000
+  Age++;
+  
   for(i = 0; i < Snaplistlen; i++)
   {
     ZZ[i] = 1 / AA[i] - 1;

--- a/code/core_mymalloc.c
+++ b/code/core_mymalloc.c
@@ -54,6 +54,44 @@ void *mymalloc(size_t n)
 }
 
 
+void *myrealloc(void *p, size_t n)
+{
+  if((n % 8) > 0)
+    n = (n / 8 + 1) * 8;
+
+  if(n == 0)
+    n = 8;
+
+   if(p != Table[Nblocks - 1])
+   {
+      printf("Wrong call of myrealloc() p = %p is not the last allocated block = %p!\n", p, Table[Nblocks-1]);
+      ABORT(0);
+  }
+  
+  void *newp = realloc(Table[Nblocks-1], n);
+  if(newp == NULL) {
+      printf("Failed to re-allocate memory for %g MB (old size = %g MB)\n",  n / (1024.0 * 1024.0), SizeTable[Nblocks-1]/ (1024.0 * 1024.0) );
+      ABORT(0);
+   }
+  Table[Nblocks-1] = newp;
+  
+  TotMem -= SizeTable[Nblocks-1];
+  TotMem += n;
+  SizeTable[Nblocks-1] = n;
+  
+  if(TotMem > HighMarkMem)
+  {
+    HighMarkMem = TotMem;
+    if(HighMarkMem > OldPrintedHighMark + 10 * 1024.0 * 1024.0)
+    {
+      printf("new high mark = %g MB\n", HighMarkMem / (1024.0 * 1024.0));
+      OldPrintedHighMark = HighMarkMem;
+    }
+  }
+
+  return Table[Nblocks - 1];
+}
+
 
 void myfree(void *p)
 {

--- a/code/core_proto.h
+++ b/code/core_proto.h
@@ -22,6 +22,7 @@ void print_allocated(void);
 
 void read_parameter_file(char *fname);
 void *mymalloc(size_t n);
+void *myrealloc(void *p, size_t n);
 void myfree(void *p);
 void myexit(int signum);
 

--- a/code/main.c
+++ b/code/main.c
@@ -168,6 +168,11 @@ int main(int argc, char **argv)
     printf("\ndone file %d\n\n", filenr);
   }
 
+  //free Ages. But first
+  //reset Age to the actual allocated address
+  Age--;
+  myfree(Age);                              
+  
   exitfail = 0;
   return 0;
 }


### PR DESCRIPTION
Fixes the hardcoded fof_maxgals issue. `sage` can now handle very high-res simulations natively (assuming that enough memory is available). 
