### PR TITLE
Initialize galaxy_output.

### DIFF
--- a/code/core_save.c
+++ b/code/core_save.c
@@ -19,7 +19,7 @@ void save_galaxies(int filenr, int tree)
 {
   char buf[1000];
   int i, n;
-  struct GALAXY_OUTPUT galaxy_output;
+  struct GALAXY_OUTPUT galaxy_output = {0};
   int OutputGalCount[MAXSNAPS], *OutputGalOrder;
 
   OutputGalOrder = (int*)malloc( NumGals*sizeof(int) );

--- a/code/main.c
+++ b/code/main.c
@@ -172,6 +172,8 @@ int main(int argc, char **argv)
   //reset Age to the actual allocated address
   Age--;
   myfree(Age);                              
+
+  gsl_rng_free(random_generator);
   
   exitfail = 0;
   return 0;


### PR DESCRIPTION
Since struct(GALAXY_OUTPUT) is not aligned to 8 bytes it contains a pad.
When writing out the galaxies uninitialized bytes are then written out.
This commit fixes this by initializing the struct (including the pad) to
0.

Also properly free the GSL random_generator.

Valgrind produces no memory leaks, warnings or errors.