### PR TITLE
allresults.py bug fix: integers for histograms

### DIFF
--- a/output/allresults.py
+++ b/output/allresults.py
@@ -231,7 +231,7 @@ class Results:
 
         mi = np.floor(min(mass)) - 2
         ma = np.floor(max(mass)) + 2
-        NB = (ma - mi) / binwidth
+        NB = int(np.floor((ma - mi) / binwidth))
 
         (counts, binedges) = np.histogram(mass, range=(mi, ma), bins=NB)
 
@@ -381,7 +381,7 @@ class Results:
 
         mi = np.floor(min(mass)) - 2
         ma = np.floor(max(mass)) + 2
-        NB = (ma - mi) / binwidth
+        NB = int(np.floor((ma - mi) / binwidth))
 
         (counts, binedges) = np.histogram(mass, range=(mi, ma), bins=NB)
 
@@ -447,7 +447,7 @@ class Results:
         sSFR = (G.SfrDisk[w] + G.SfrBulge[w]) / (G.StellarMass[w] * 1.0e10 / self.Hubble_h)
         mi = np.floor(min(mass)) - 2
         ma = np.floor(max(mass)) + 2
-        NB = (ma - mi) / binwidth
+        NB = int(np.floor((ma - mi) / binwidth))
 
         (counts, binedges) = np.histogram(mass, range=(mi, ma), bins=NB)
 
@@ -1097,7 +1097,7 @@ class Results:
         mi = -0.02
         ma = 0.5
         binwidth = 0.01
-        NB = (ma - mi) / binwidth
+        NB = int(np.floor((ma - mi) / binwidth))
 
         (counts, binedges) = np.histogram(SpinParameter, range=(mi, ma), bins=NB)
         xaxeshisto = binedges[:-1] + 0.5 * binwidth
@@ -1133,7 +1133,7 @@ class Results:
         mi = -40.0
         ma = 40.0
         binwidth = 0.5
-        NB = (ma - mi) / binwidth
+        NB = int(np.floor((ma - mi) / binwidth))
 
         # set up figure
         plt.figure()


### PR DESCRIPTION
Python 2.7.12 tolerates feeding floats to np.histogram
function with a warning that the behaviour will soon be deprecated;
python 2.7.13 gives a fatal error
`````
TypeError: 'numpy.float64' object cannot be interpreted as an index
`````
Using the floor function is not enough, because it
gives float values such as 32.0 instead of integers such as 32.

This commit fixes the bug for me using python 2.7.13-2+deb9u3 (Debian GNU/Linux Stretch, which
is the stable version of Debian).