### PR TITLE
Reduce chance of string buffer overflow exploits

### DIFF
--- a/code/core_build_model.c
+++ b/code/core_build_model.c
@@ -74,7 +74,8 @@ void construct_galaxies(int halonr, int tree)
 
 int join_galaxies_of_progenitors(int halonr, int ngalstart)
 {
-  int ngal, prog, mother_halo=-1, i, j, first_occupied, lenmax, lenoccmax, centralgal;
+  int ngal, prog, i, j, first_occupied, lenmax, lenoccmax, centralgal;
+  /* int mother_halo=-1 */
   double previousMvir, previousVvir, previousVmax;
   int step;
 
@@ -95,7 +96,7 @@ int join_galaxies_of_progenitors(int halonr, int ngalstart)
     if(Halo[prog].Len > lenmax)
     {
       lenmax = Halo[prog].Len;
-      mother_halo = prog;
+      /* mother_halo = prog; */
     }
     if(lenoccmax != -1 && Halo[prog].Len > lenoccmax && HaloAux[prog].NGalaxies > 0)
     {
@@ -436,4 +437,3 @@ void evolve_galaxies(int halonr, int ngal, int tree)	// Note: halonr is here the
 
 
 }
-

--- a/code/core_init.c
+++ b/code/core_init.c
@@ -20,9 +20,9 @@ void init(void)
   int i;
 
   Age = mymalloc(ABSOLUTEMAXSNAPS*sizeof(*Age));
-  
+
   random_generator = gsl_rng_alloc(gsl_rng_ranlxd1);
-  gsl_rng_set(random_generator, 42);	 // start-up seed 
+  gsl_rng_set(random_generator, 42);     // start-up seed
 
   set_units();
   srand((unsigned) time(NULL));
@@ -33,7 +33,7 @@ void init(void)
   //This way, galsnapnum = -1 will not segfault.
   Age[0] = time_to_present(1000.0);//lookback time from z=1000
   Age++;
-  
+
   for(i = 0; i < Snaplistlen; i++)
   {
     ZZ[i] = 1 / AA[i] - 1;
@@ -63,10 +63,10 @@ void set_units(void)
   EnergySNcode = EnergySN / UnitEnergy_in_cgs * Hubble_h;
   EtaSNcode = EtaSN * (UnitMass_in_g / SOLAR_MASS) / Hubble_h;
 
-  // convert some physical input parameters to internal units 
+  // convert some physical input parameters to internal units
   Hubble = HUBBLE * UnitTime_in_s;
 
-  // compute a few quantitites 
+  // compute a few quantitites
   RhoCrit = 3 * Hubble * Hubble / (8 * M_PI * G);
 
 }
@@ -76,7 +76,7 @@ void set_units(void)
 void read_snap_list(void)
 {
   FILE *fd;
-  char fname[MAX_STRING_LEN];
+  char fname[MAX_STRING_LEN+1];
 
   snprintf(fname, MAX_STRING_LEN, "%s", FileWithSnapList);
 
@@ -123,7 +123,7 @@ double time_to_present(double z)
 
   gsl_integration_workspace_free(workspace);
 
-  // return time to present as a function of redshift 
+  // return time to present as a function of redshift
   return time;
 }
 

--- a/code/core_init.c
+++ b/code/core_init.c
@@ -76,9 +76,9 @@ void set_units(void)
 void read_snap_list(void)
 {
   FILE *fd;
-  char fname[1000];
+  char fname[MAX_STRING_LEN];
 
-  sprintf(fname, "%s", FileWithSnapList);
+  snprintf(fname, MAX_STRING_LEN, "%s", FileWithSnapList);
 
   if(!(fd = fopen(fname, "r")))
   {
@@ -133,6 +133,3 @@ double integrand_time_to_present(double a, void *param)
 {
   return 1 / sqrt(Omega / a + (1 - Omega - OmegaLambda) + OmegaLambda * a * a);
 }
-
-
-

--- a/code/core_io_tree.c
+++ b/code/core_io_tree.c
@@ -16,13 +16,15 @@
 #include "io/tree_hdf5.h"
 #endif
 
-#define MAX_BUF_SIZE (3*MAX_STRING_LEN+20)
+#ifndef MAX_BUF_SIZE
+#define MAX_BUF_SIZE (3*MAX_STRING_LEN+40)
+#endif
 
 void load_tree_table(int filenr, enum Valid_TreeTypes my_TreeType)
 {
   int i, n;
   FILE *fd;
-  char buf[MAX_BUF_SIZE];
+  char buf[MAX_BUF_SIZE+1];
 
   switch (my_TreeType)
   {
@@ -31,7 +33,7 @@ void load_tree_table(int filenr, enum Valid_TreeTypes my_TreeType)
       load_tree_table_hdf5(filenr);
       break;
 #endif
-      
+
     case lhalo_binary:
       load_tree_table_binary(filenr);
       break;
@@ -70,7 +72,7 @@ void free_tree_table(enum Valid_TreeTypes my_TreeType)
 
   myfree(TreeFirstHalo);
   myfree(TreeNHalos);
-	
+
   // Don't forget to free the open file handle
 
   switch (my_TreeType)
@@ -80,7 +82,7 @@ void free_tree_table(enum Valid_TreeTypes my_TreeType)
       close_hdf5_file();
       break;
 #endif
-      
+
     case lhalo_binary:
       close_binary_file();
       break;

--- a/code/core_io_tree.c
+++ b/code/core_io_tree.c
@@ -16,11 +16,13 @@
 #include "io/tree_hdf5.h"
 #endif
 
+#define MAX_BUF_SIZE (3*MAX_STRING_LEN+20)
+
 void load_tree_table(int filenr, enum Valid_TreeTypes my_TreeType)
 {
   int i, n;
   FILE *fd;
-  char buf[MAX_STRING_LEN];
+  char buf[MAX_BUF_SIZE];
 
   switch (my_TreeType)
   {
@@ -46,7 +48,7 @@ void load_tree_table(int filenr, enum Valid_TreeTypes my_TreeType)
     for(i = 0; i < Ntrees; i++)
       TreeNgals[n][i] = 0;
 
-    sprintf(buf, "%s/%s_z%1.3f_%d", OutputDir, FileNameGalaxies, ZZ[ListOutputSnaps[n]], filenr);
+    snprintf(buf, MAX_BUF_SIZE, "%s/%s_z%1.3f_%d", OutputDir, FileNameGalaxies, ZZ[ListOutputSnaps[n]], filenr);
 
     if(!(fd = fopen(buf, "w")))
     {

--- a/code/core_read_parameter_file.c
+++ b/code/core_read_parameter_file.c
@@ -10,7 +10,8 @@
 void read_parameter_file(char *fname)
 {
   FILE *fd;
-  char buf[MAX_STRING_LEN], buf1[MAX_STRING_LEN];
+#define MAX_BUF_SIZE_FILE_LIST (3*MAX_STRING_LEN)
+  char buf[MAX_BUF_SIZE_FILE_LIST], buf1[MAX_STRING_LEN];
   char buf2[MAX_STRING_LEN], buf3[MAX_STRING_LEN];
   int i, j, done;
   int errorFlag = 0;
@@ -194,7 +195,7 @@ void read_parameter_file(char *fname)
     while(!feof(fd))
       {
 	*buf = 0;
-	fgets(buf, 200, fd);
+	fgets(buf, MAX_BUF_SIZE_FILE_LIST, fd);
 	if(sscanf(buf, "%s%s%s", buf1, buf2, buf3) < 2)
 	  continue;
 	

--- a/code/core_read_parameter_file.c
+++ b/code/core_read_parameter_file.c
@@ -11,7 +11,8 @@ void read_parameter_file(char *fname)
 {
   FILE *fd;
 #define MAX_BUF_SIZE_FILE_LIST (3*MAX_STRING_LEN)
-  char buf[MAX_BUF_SIZE_FILE_LIST], buf1[MAX_STRING_LEN];
+  char buf[MAX_BUF_SIZE_FILE_LIST];
+  char buf1[MAX_STRING_LEN];
   char buf2[MAX_STRING_LEN], buf3[MAX_STRING_LEN];
   int i, j, done;
   int errorFlag = 0;
@@ -189,93 +190,93 @@ void read_parameter_file(char *fname)
     printf("Parameter file %s not found.\n", fname);
     errorFlag = 1;
   }
-  
-  if(fd != NULL) 
+
+  if(fd != NULL)
   {
     while(!feof(fd))
       {
-	*buf = 0;
-	fgets(buf, MAX_BUF_SIZE_FILE_LIST, fd);
-	if(sscanf(buf, "%s%s%s", buf1, buf2, buf3) < 2)
-	  continue;
-	
-	if(buf1[0] == '%' || buf1[0] == '-')
-	  continue;
-	
-	for(i = 0, j = -1; i < NParam; i++)
-	  if(strcmp(buf1, ParamTag[i]) == 0)
-	    {
-	      j = i;
-	      ParamTag[i][0] = 0;
-	      used_tag[i] = 0;
-	      break;
-	    }
-	
-	if(j >= 0)
-	  {
+        *buf = 0;
+        fgets(buf, MAX_BUF_SIZE_FILE_LIST, fd);
+        if(sscanf(buf, "%s%s%s", buf1, buf2, buf3) < 2)
+          continue;
+
+        if(buf1[0] == '%' || buf1[0] == '-')
+          continue;
+
+        for(i = 0, j = -1; i < NParam; i++)
+          if(strcmp(buf1, ParamTag[i]) == 0)
+            {
+              j = i;
+              ParamTag[i][0] = 0;
+              used_tag[i] = 0;
+              break;
+            }
+
+        if(j >= 0)
+          {
 #ifdef MPI
-	    if(ThisTask == 0)
+            if(ThisTask == 0)
 #endif
-	      printf("%35s\t%10s\n", buf1, buf2);
-	    
-	    switch (ParamID[j])
-	      {
-	      case DOUBLE:
-		*((double *) ParamAddr[j]) = atof(buf2);
-		break;
-	      case STRING:
-		strcpy(ParamAddr[j], buf2);
-		break;
-	      case INT:
-		*((int *) ParamAddr[j]) = atoi(buf2);
-		break;
-	      }
-	  }
-	else
-	{
-	  printf("Error in file %s:   Tag '%s' not allowed or multiply defined.\n", fname, buf1);
-	  errorFlag = 1;
-	}
+              printf("%35s\t%10s\n", buf1, buf2);
+
+            switch (ParamID[j])
+              {
+              case DOUBLE:
+                *((double *) ParamAddr[j]) = atof(buf2);
+                break;
+              case STRING:
+                strcpy(ParamAddr[j], buf2);
+                break;
+              case INT:
+                *((int *) ParamAddr[j]) = atoi(buf2);
+                break;
+              }
+          }
+        else
+        {
+          printf("Error in file %s:   Tag '%s' not allowed or multiply defined.\n", fname, buf1);
+          errorFlag = 1;
+        }
       }
     fclose(fd);
 
     i = strlen(OutputDir);
     if(i > 0)
       if(OutputDir[i - 1] != '/')
-	strcat(OutputDir, "/");
+        strcat(OutputDir, "/");
   }
-  
+
   for(i = 0; i < NParam; i++)
     {
       if(used_tag[i])
-	{
-	  printf("Error. I miss a value for tag '%s' in parameter file '%s'.\n", ParamTag[i], fname);
-	  errorFlag = 1;
-	}
+        {
+          printf("Error. I miss a value for tag '%s' in parameter file '%s'.\n", ParamTag[i], fname);
+          errorFlag = 1;
+        }
     }
-  
+
   if(errorFlag) {
     ABORT(1);
   }
   printf("\n");
-  
+
   if( ! (LastSnapShotNr+1 > 0 && LastSnapShotNr+1 < ABSOLUTEMAXSNAPS) ) {
     fprintf(stderr,"LastSnapshotNr = %d should be in [0, %d) \n", LastSnapShotNr, ABSOLUTEMAXSNAPS);
     ABORT(1);
   }
   MAXSNAPS = LastSnapShotNr + 1;
-  
+
   if(!(NOUT == -1 || (NOUT > 0 && NOUT <= ABSOLUTEMAXSNAPS))) {
     fprintf(stderr,"NumOutputs must be -1 or between 1 and %i\n", ABSOLUTEMAXSNAPS);
     ABORT(1);
   }
-  
+
   // read in the output snapshot list
   if(NOUT == -1)
     {
       NOUT = MAXSNAPS;
       for (i=NOUT-1; i>=0; i--)
-	ListOutputSnaps[i] = i;
+        ListOutputSnaps[i] = i;
       printf("all %i snapshots selected for output\n", NOUT);
     }
   else
@@ -283,34 +284,34 @@ void read_parameter_file(char *fname)
       printf("%i snapshots selected for output: ", NOUT);
       // reopen the parameter file
       fd = fopen(fname, "r");
-      
+
       done = 0;
       while(!feof(fd) && !done)
-	{
-	  // scan down to find the line with the snapshots
-	  fscanf(fd, "%s", buf);
-	  if(strcmp(buf, "->") == 0)
-	    {
-	      // read the snapshots into ListOutputSnaps
-	      for (i=0; i<NOUT; i++)
-		{
-		  fscanf(fd, "%d", &ListOutputSnaps[i]);
-		  printf("%i ", ListOutputSnaps[i]);
-		}
-	      done = 1;
-	    }
-	}
-      
+        {
+          // scan down to find the line with the snapshots
+          fscanf(fd, "%s", buf);
+          if(strcmp(buf, "->") == 0)
+            {
+              // read the snapshots into ListOutputSnaps
+              for (i=0; i<NOUT; i++)
+                {
+                  fscanf(fd, "%d", &ListOutputSnaps[i]);
+                  printf("%i ", ListOutputSnaps[i]);
+                }
+              done = 1;
+            }
+        }
+
       fclose(fd);
       if(! done ) {
-	fprintf(stderr,"Error: Could not properly parse output snapshots\n");
-	ABORT(2);
+        fprintf(stderr,"Error: Could not properly parse output snapshots\n");
+        ABORT(2);
       }
       printf("\n");
     }
-  
-  // Check file type is valid. 
-  if (strncmp(my_treetype, "lhalo_binary", 511) != 0) // strncmp returns 0 if the two strings are equal. Only available options are HDF5 or binary files. 
+
+  // Check file type is valid.
+  if (strncmp(my_treetype, "lhalo_binary", 511) != 0) // strncmp returns 0 if the two strings are equal. Only available options are HDF5 or binary files.
   {
     snprintf(TreeExtension, 511, ".hdf5");
 #ifndef HDF5
@@ -337,6 +338,5 @@ void read_parameter_file(char *fname)
   }
 
   myfree(used_tag);
-  
-}
 
+}

--- a/code/core_save.c
+++ b/code/core_save.c
@@ -14,12 +14,16 @@
 // keep a static file handle to remove the need to do constant seeking.
 FILE* save_fd[ABSOLUTEMAXSNAPS] = { 0 };
 
+#define MAX_BUF_SIZE (2*MAX_STRING_LEN+40)
+#define MAX_OUTFILE_SIZE (MAX_STRING_LEN+40)
 
 void save_galaxies(int filenr, int tree)
 {
   char buf[MAX_STRING_LEN];
   int i, n;
-  struct GALAXY_OUTPUT galaxy_output = {0};
+  static const struct GALAXY_OUTPUT galaxy_output_null = {0};
+  struct GALAXY_OUTPUT galaxy_output = galaxy_output_null;
+
   int OutputGalCount[MAXSNAPS], *OutputGalOrder, nwritten;
 
   OutputGalOrder = (int*)malloc( NumGals*sizeof(int) );
@@ -57,7 +61,8 @@ void save_galaxies(int filenr, int tree)
       // only open the file if it is not already open.
       if( !save_fd[n] )
 	    {
-        snprintf(buf, MAX_STRING_LEN - 1, "%s/%s_z%1.3f_%d", OutputDir, FileNameGalaxies, ZZ[ListOutputSnaps[n]], filenr);
+        snprintf(buf, MAX_BUF_SIZE - 1, "%s/%s_z%1.3f_%d", OutputDir, FileNameGalaxies, ZZ[ListOutputSnaps[n]], filenr);
+        
        
         save_fd[n] = fopen(buf, "r+");
         if (save_fd[n] == NULL) 
@@ -273,4 +278,3 @@ void finalize_galaxy_file(int filenr)
 
 #undef TREE_MUL_FAC
 #undef FILENR_MUL_FAC
-

--- a/code/core_save.c
+++ b/code/core_save.c
@@ -14,12 +14,14 @@
 // keep a static file handle to remove the need to do constant seeking.
 FILE* save_fd[ABSOLUTEMAXSNAPS] = { 0 };
 
-#define MAX_BUF_SIZE (2*MAX_STRING_LEN+40)
+#ifndef MAX_BUF_SIZE
+#define MAX_BUF_SIZE (3*MAX_STRING_LEN+40)
+#endif
 #define MAX_OUTFILE_SIZE (MAX_STRING_LEN+40)
 
 void save_galaxies(int filenr, int tree)
 {
-  char buf[MAX_STRING_LEN];
+  char buf[MAX_BUF_SIZE+1];
   int i, n;
   static const struct GALAXY_OUTPUT galaxy_output_null = {0};
   struct GALAXY_OUTPUT galaxy_output = galaxy_output_null;
@@ -37,40 +39,40 @@ void save_galaxies(int filenr, int tree)
     OutputGalCount[i] = 0;
   for(i = 0; i < NumGals; i++)
     OutputGalOrder[i] = -1;
-  
+
   // first update mergeIntoID to point to the correct galaxy in the output
   for(n = 0; n < NOUT; n++)
     {
       for(i = 0; i < NumGals; i++)
-	{
-	  if(HaloGal[i].SnapNum == ListOutputSnaps[n])
-	    {
-	      OutputGalOrder[i] = OutputGalCount[n];
-	      OutputGalCount[n]++;
-	    }
-	}
+        {
+          if(HaloGal[i].SnapNum == ListOutputSnaps[n])
+            {
+              OutputGalOrder[i] = OutputGalCount[n];
+              OutputGalCount[n]++;
+            }
+        }
     }
-  
+
   for(i = 0; i < NumGals; i++)
     if(HaloGal[i].mergeIntoID > -1)
-      HaloGal[i].mergeIntoID = OutputGalOrder[HaloGal[i].mergeIntoID];    
-  
+      HaloGal[i].mergeIntoID = OutputGalOrder[HaloGal[i].mergeIntoID];
+
   // now prepare and write galaxies
   for(n = 0; n < NOUT; n++)
   {
       // only open the file if it is not already open.
       if( !save_fd[n] )
-	    {
-        snprintf(buf, MAX_BUF_SIZE - 1, "%s/%s_z%1.3f_%d", OutputDir, FileNameGalaxies, ZZ[ListOutputSnaps[n]], filenr);
-        
-       
+            {
+        snprintf(buf, MAX_BUF_SIZE, "%s/%s_z%1.3f_%d", OutputDir, FileNameGalaxies, ZZ[ListOutputSnaps[n]], filenr);
+
+
         save_fd[n] = fopen(buf, "r+");
-        if (save_fd[n] == NULL) 
+        if (save_fd[n] == NULL)
         {
           fprintf(stderr, "can't open file `%s'\n", buf);
           ABORT(0);
         }
-        
+
         // write out placeholders for the header data.
         size_t size = (Ntrees + 2)*sizeof(int); /* Extra two inegers are for saving the total number of trees and total number of galaxies in this file */
         int* tmp_buf = (int*)malloc( size );
@@ -87,25 +89,25 @@ void save_galaxies(int filenr, int tree)
           fprintf(stderr, "Error: Failed to write out %d elements for header information for file %d.  Only wrote %d elements.\n", Ntrees + 2, n, nwritten);
         }
         free( tmp_buf );
-	    }
-      
+            }
+
       for(i = 0; i < NumGals; i++)
-	    {
+            {
         if(HaloGal[i].SnapNum == ListOutputSnaps[n])
-	      {        
+              {
           prepare_galaxy_for_output(filenr, tree, &HaloGal[i], &galaxy_output);
-   
+
           nwritten = myfwrite(&galaxy_output, sizeof(struct GALAXY_OUTPUT), 1, save_fd[n]);
           if (nwritten != 1)
           {
-            fprintf(stderr, "Error: Failed to write out the galaxy struct for galaxy %d within file %d.  Meant to write 1 element but only wrote %d elements.\n", i, n, nwritten); 
+            fprintf(stderr, "Error: Failed to write out the galaxy struct for galaxy %d within file %d.  Meant to write 1 element but only wrote %d elements.\n", i, n, nwritten);
           }
-          
+
           TotGalaxies[n]++;
-          TreeNgals[n][tree]++;	      
-	      }
-	    }
-      
+          TreeNgals[n][tree]++;
+              }
+            }
+
   }
 
   // don't forget to free the workspace.
@@ -124,7 +126,7 @@ void prepare_galaxy_for_output(int filenr, int tree, struct GALAXY *g, struct GA
 
   // assume that because there are so many files, the trees per file will be less than 100000
   // required for limits of long long
-  if(LastFile>=10000) 
+  if(LastFile>=10000)
   {
       assert( g->GalaxyNr < TREE_MUL_FAC ); // breaking tree size assumption
       assert(tree < (FILENR_MUL_FAC/10)/TREE_MUL_FAC);
@@ -144,7 +146,7 @@ void prepare_galaxy_for_output(int filenr, int tree, struct GALAXY *g, struct GA
       assert( o->GalaxyIndex - TREE_MUL_FAC*tree - FILENR_MUL_FAC*filenr == g->GalaxyNr );
       o->CentralGalaxyIndex = HaloGal[HaloAux[Halo[g->HaloNr].FirstHaloInFOFgroup].FirstGalaxy].GalaxyNr + TREE_MUL_FAC * tree + FILENR_MUL_FAC * filenr;
   }
-    
+
   o->SAGEHaloIndex = g->HaloNr;
   o->SAGETreeIndex = tree;
   o->SimulationHaloIndex = Halo[g->HaloNr].MostBoundID;
@@ -183,18 +185,18 @@ void prepare_galaxy_for_output(int filenr, int tree, struct GALAXY *g, struct GA
   o->MetalsHotGas = g->MetalsHotGas;
   o->MetalsEjectedMass = g->MetalsEjectedMass;
   o->MetalsICS = g->MetalsICS;
-  
+
   o->SfrDisk = 0.0;
   o->SfrBulge = 0.0;
   o->SfrDiskZ = 0.0;
   o->SfrBulgeZ = 0.0;
-  
-  // NOTE: in Msun/yr 
+
+  // NOTE: in Msun/yr
   for(step = 0; step < STEPS; step++)
   {
     o->SfrDisk += g->SfrDisk[step] * UnitMass_in_g / UnitTime_in_s * SEC_PER_YEAR / SOLAR_MASS / STEPS;
     o->SfrBulge += g->SfrBulge[step] * UnitMass_in_g / UnitTime_in_s * SEC_PER_YEAR / SOLAR_MASS / STEPS;
-    
+
     if(g->SfrDiskColdGas[step] > 0.0)
       o->SfrDiskZ += g->SfrDiskColdGasMetals[step] / g->SfrDiskColdGas[step] / STEPS;
 
@@ -217,7 +219,7 @@ void prepare_galaxy_for_output(int filenr, int tree, struct GALAXY *g, struct GA
 
   o->TimeOfLastMajorMerger = g->TimeOfLastMajorMerger * UnitTime_in_Megayears;
   o->TimeOfLastMinorMerger = g->TimeOfLastMinorMerger * UnitTime_in_Megayears;
-	
+
   o->OutflowRate = g->OutflowRate * UnitMass_in_g / UnitTime_in_s * SEC_PER_YEAR / SOLAR_MASS;
 
   //infall properties
@@ -251,19 +253,19 @@ void finalize_galaxy_file(int filenr)
     fseek( save_fd[n], 0, SEEK_SET );
 
     nwritten = myfwrite(&Ntrees, sizeof(int), 1, save_fd[n]);
-    if (nwritten != 1) 
+    if (nwritten != 1)
     {
       fprintf(stderr, "Error: Failed to write out 1 element for the number of trees for the header of file %d.  Only wrote %d elements.\n", n, nwritten);
     }
 
     nwritten = myfwrite(&TotGalaxies[n], sizeof(int), 1, save_fd[n]);
-    if (nwritten != 1) 
+    if (nwritten != 1)
     {
       fprintf(stderr, "Error: Failed to write out 1 element for the number of galaxies for the header of file %d.  Only wrote %d elements.\n", n, nwritten);
     }
 
     nwritten = myfwrite(TreeNgals[n], sizeof(int), Ntrees, save_fd[n]);
-    if (nwritten != Ntrees) 
+    if (nwritten != Ntrees)
     {
       fprintf(stderr, "Error: Failed to write out %d elements for the number of galaxies per tree for the header of file %d.  Only wrote %d elements.\n", Ntrees, n, nwritten);
     }
@@ -273,7 +275,7 @@ void finalize_galaxy_file(int filenr)
     fclose( save_fd[n] );
     save_fd[n] = NULL;
   }
-  
+
 }
 
 #undef TREE_MUL_FAC

--- a/code/io/tree_binary.c
+++ b/code/io/tree_binary.c
@@ -20,14 +20,16 @@ FILE *load_fd;
 
 // External Functions //
 
+#ifndef MAX_BUF_SIZE
 #define MAX_BUF_SIZE (3*MAX_STRING_LEN+40)
+#endif
 
-void load_tree_table_binary(int32_t filenr) 
+void load_tree_table_binary(int32_t filenr)
 {
   int i, totNHalos;
-  char buf[MAX_BUF_SIZE];
+  char buf[MAX_BUF_SIZE+1];
 
-	// open the file each time this function is called
+        // open the file each time this function is called
   snprintf(buf, MAX_BUF_SIZE, "%s/%s.%d%s", SimulationDir, TreeName, filenr, TreeExtension);
   if(!(load_fd = fopen(buf, "r")))
   {
@@ -63,7 +65,7 @@ void load_tree_binary(int32_t filenr, int32_t treenr)
 
 void close_binary_file(void)
 {
-  if(load_fd) 
+  if(load_fd)
   {
     fclose(load_fd);
     load_fd = NULL;

--- a/code/io/tree_binary.c
+++ b/code/io/tree_binary.c
@@ -20,13 +20,15 @@ FILE *load_fd;
 
 // External Functions //
 
+#define MAX_BUF_SIZE (3*MAX_STRING_LEN+40)
+
 void load_tree_table_binary(int32_t filenr) 
 {
   int i, totNHalos;
-  char buf[MAX_STRING_LEN];
+  char buf[MAX_BUF_SIZE];
 
 	// open the file each time this function is called
-  snprintf(buf, MAX_STRING_LEN, "%s/%s.%d%s", SimulationDir, TreeName, filenr, TreeExtension);
+  snprintf(buf, MAX_BUF_SIZE, "%s/%s.%d%s", SimulationDir, TreeName, filenr, TreeExtension);
   if(!(load_fd = fopen(buf, "r")))
   {
     printf("can't open file `%s'\n", buf);
@@ -68,4 +70,3 @@ void close_binary_file(void)
   }
 }
 // Local Functions //
-

--- a/code/io/tree_hdf5.c
+++ b/code/io/tree_hdf5.c
@@ -17,12 +17,12 @@ static hid_t hdf5_file;
 
 // Local Structs //
 
-struct METADATA_NAMES 
+struct METADATA_NAMES
 {
-  char name_NTrees[MAX_STRING_LEN];
-  char name_totNHalos[MAX_STRING_LEN];
-  char name_TreeNHalos[MAX_STRING_LEN];
-}; 
+  char name_NTrees[MAX_STRING_LEN+1];
+  char name_totNHalos[MAX_STRING_LEN+1];
+  char name_TreeNHalos[MAX_STRING_LEN+1];
+};
 
 // Local Proto-Types //
 
@@ -35,19 +35,19 @@ int32_t read_dataset(hid_t my_hdf5_file, char *dataset_name, int32_t datatype, v
 void load_tree_table_hdf5(int filenr)
 {
 
-  char buf[MAX_STRING_LEN];
+  char buf[MAX_STRING_LEN+1];
   int32_t totNHalos, i;
   int32_t status;
 
   struct METADATA_NAMES metadata_names;
 
-  snprintf(buf, MAX_STRING_LEN - 1, "%s/%s.%d%s", SimulationDir, TreeName, filenr, TreeExtension);
+  snprintf(buf, MAX_STRING_LEN, "%s/%s.%d%s", SimulationDir, TreeName, filenr, TreeExtension);
   hdf5_file = H5Fopen(buf, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   if (hdf5_file < 0)
   {
     printf("can't open file `%s'\n", buf);
-    ABORT(0);    
+    ABORT(0);
   }
 
   status = fill_metadata_names(&metadata_names, TreeType);
@@ -55,7 +55,7 @@ void load_tree_table_hdf5(int filenr)
   {
     ABORT(0);
   }
- 
+
   status = read_attribute_int(hdf5_file, "/Header", metadata_names.name_NTrees, &Ntrees);
   if (status != EXIT_SUCCESS)
   {
@@ -65,7 +65,7 @@ void load_tree_table_hdf5(int filenr)
   }
 
   status = read_attribute_int(hdf5_file, "/Header", metadata_names.name_totNHalos, &totNHalos);
-  if (status != EXIT_SUCCESS)  
+  if (status != EXIT_SUCCESS)
   {
     fprintf(stderr, "Error while processing file %s\n", buf);
     fprintf(stderr, "Error code is %d\n", status);
@@ -73,8 +73,8 @@ void load_tree_table_hdf5(int filenr)
   }
 
   printf("There are %d trees and %d total halos\n", Ntrees, totNHalos);
-  
-  TreeNHalos = mymalloc(sizeof(int) * Ntrees); 
+
+  TreeNHalos = mymalloc(sizeof(int) * Ntrees);
 
   status = read_attribute_int(hdf5_file, "/Header", metadata_names.name_TreeNHalos, TreeNHalos);
   if (status != EXIT_SUCCESS)
@@ -98,7 +98,7 @@ void load_tree_table_hdf5(int filenr)
 
 #define READ_TREE_PROPERTY(sage_name, hdf5_name, type_int, data_type) \
 { \
-  snprintf(dataset_name, MAX_STRING_LEN - 1, "tree_%03d/%s", treenr, #hdf5_name);\
+  snprintf(dataset_name, MAX_STRING_LEN, "tree_%03d/%s", treenr, #hdf5_name);\
   status = read_dataset(hdf5_file, dataset_name, type_int, buffer);\
   if (status != EXIT_SUCCESS) \
   {\
@@ -112,7 +112,7 @@ void load_tree_table_hdf5(int filenr)
 
 #define READ_TREE_PROPERTY_MULTIPLEDIM(sage_name, hdf5_name, type_int, data_type) \
 { \
-  snprintf(dataset_name, MAX_STRING_LEN - 1, "tree_%03d/%s", treenr, #hdf5_name);\
+  snprintf(dataset_name, MAX_STRING_LEN, "tree_%03d/%s", treenr, #hdf5_name);\
   status = read_dataset(hdf5_file, dataset_name, type_int, buffer_multipledim);\
   if (status != EXIT_SUCCESS) \
   {\
@@ -131,11 +131,11 @@ void load_tree_table_hdf5(int filenr)
 void load_tree_hdf5(int32_t filenr, int32_t treenr)
 {
 
-  char dataset_name[MAX_STRING_LEN];
+  char dataset_name[MAX_STRING_LEN+1];
   int32_t NHalos_ThisTree, status, halo_idx, dim;
 
-  double *buffer; // Buffer to hold the read HDF5 data.  
-                  // The largest data-type will be double. 
+  double *buffer; // Buffer to hold the read HDF5 data.
+                  // The largest data-type will be double.
 
   double *buffer_multipledim; // However also need a buffer three times as large to hold data such as position/velocity.
 
@@ -148,7 +148,7 @@ void load_tree_hdf5(int32_t filenr, int32_t treenr)
 
   NHalos_ThisTree = TreeNHalos[treenr];
 
-  Halo = mymalloc(sizeof(struct halo_data) * NHalos_ThisTree); 
+  Halo = mymalloc(sizeof(struct halo_data) * NHalos_ThisTree);
 
   buffer = calloc(NHalos_ThisTree, sizeof(*(buffer)));
   if (buffer == NULL)
@@ -157,7 +157,7 @@ void load_tree_hdf5(int32_t filenr, int32_t treenr)
     ABORT(0);
   }
 
-  buffer_multipledim = calloc(NHalos_ThisTree * NDIM, sizeof(*(buffer_multipledim))); 
+  buffer_multipledim = calloc(NHalos_ThisTree * NDIM, sizeof(*(buffer_multipledim)));
   if (buffer_multipledim == NULL)
   {
     fprintf(stderr, "Could not allocate memory for the HDF5 multiple dimension buffer.\n");
@@ -167,14 +167,14 @@ void load_tree_hdf5(int32_t filenr, int32_t treenr)
   // We now need to read in all the halo fields for this tree.
   // To do so, we read the field into a buffer and then properly slot the field into the Halo struct.
 
-  /* Merger Tree Pointers */ 
+  /* Merger Tree Pointers */
   READ_TREE_PROPERTY(Descendant, Descendant, 0, int);
   READ_TREE_PROPERTY(FirstProgenitor, FirstProgenitor, 0, int);
   READ_TREE_PROPERTY(NextProgenitor, NextProgenitor, 0, int);
   READ_TREE_PROPERTY(FirstHaloInFOFgroup, FirstHaloInFOFgroup, 0, int);
   READ_TREE_PROPERTY(NextHaloInFOFgroup, NextHaloInFOFgroup, 0, int);
 
-  /* Halo Properties */ 
+  /* Halo Properties */
   READ_TREE_PROPERTY(Len, Len, 0, int);
   READ_TREE_PROPERTY(M_Mean200, M_mean200, 1, float);
   READ_TREE_PROPERTY(Mvir, Mvir, 1, float);
@@ -195,15 +195,15 @@ void load_tree_hdf5(int32_t filenr, int32_t treenr)
   free(buffer);
   free(buffer_multipledim);
 
-#ifdef DEBUG_HDF5_READER 
+#ifdef DEBUG_HDF5_READER
   int32_t i;
   for (i = 0; i < 20; ++i)
-  { 
-    printf("halo %d: Descendant %d FirstProg %d x %.4f y %.4f z %.4f\n", i, Halo[i].Descendant, Halo[i].FirstProgenitor, Halo[i].Pos[0], Halo[i].Pos[1], Halo[i].Pos[2]); 
+  {
+    printf("halo %d: Descendant %d FirstProg %d x %.4f y %.4f z %.4f\n", i, Halo[i].Descendant, Halo[i].FirstProgenitor, Halo[i].Pos[0], Halo[i].Pos[1], Halo[i].Pos[2]);
   }
   ABORT(0);
-#endif 
- 
+#endif
+
 }
 
 #undef READ_TREE_PROPERTY
@@ -224,14 +224,14 @@ int32_t fill_metadata_names(struct METADATA_NAMES *metadata_names, enum Valid_Tr
   switch (my_TreeType)
   {
 
-    case genesis_lhalo_hdf5: 
-  
-      snprintf(metadata_names->name_NTrees, MAX_STRING_LEN - 1, "Ntrees"); // Total number of trees within the file.
-      snprintf(metadata_names->name_totNHalos, MAX_STRING_LEN - 1, "totNHalos"); // Total number of halos within the file.
-      snprintf(metadata_names->name_TreeNHalos, MAX_STRING_LEN - 1, "TreeNHalos"); // Number of halos per tree within the file.
+    case genesis_lhalo_hdf5:
+
+      snprintf(metadata_names->name_NTrees, MAX_STRING_LEN, "Ntrees"); // Total number of trees within the file.
+      snprintf(metadata_names->name_totNHalos, MAX_STRING_LEN, "totNHalos"); // Total number of halos within the file.
+      snprintf(metadata_names->name_TreeNHalos, MAX_STRING_LEN, "TreeNHalos"); // Number of halos per tree within the file.
       return EXIT_SUCCESS;
 
-    case lhalo_binary: 
+    case lhalo_binary:
       fprintf(stderr, "If the file is binary then this function should never be called.  Something's gone wrong...");
       return EXIT_FAILURE;
 
@@ -250,7 +250,7 @@ int32_t read_attribute_int(hid_t my_hdf5_file, char *groupname, char *attr_name,
 {
 
   int32_t status;
-  hid_t attr_id; 
+  hid_t attr_id;
 
   attr_id = H5Aopen_by_name(my_hdf5_file, groupname, attr_name, H5P_DEFAULT, H5P_DEFAULT);
   if (attr_id < 0)
@@ -265,15 +265,15 @@ int32_t read_attribute_int(hid_t my_hdf5_file, char *groupname, char *attr_name,
     fprintf(stderr, "Could not read the attribute %s in group %s\n", attr_name, groupname);
     return status;
   }
-    
+
   status = H5Aclose(attr_id);
   if (status < 0)
   {
-    fprintf(stderr, "Error when closing the file.\n"); 
+    fprintf(stderr, "Error when closing the file.\n");
     return status;
   }
-   
-  return EXIT_SUCCESS; 
+
+  return EXIT_SUCCESS;
 }
 
 int32_t read_dataset(hid_t my_hdf5_file, char *dataset_name, int32_t datatype, void *buffer)
@@ -283,19 +283,19 @@ int32_t read_dataset(hid_t my_hdf5_file, char *dataset_name, int32_t datatype, v
   dataset_id = H5Dopen2(hdf5_file, dataset_name, H5P_DEFAULT);
   if (dataset_id < 0)
   {
-    fprintf(stderr, "Error %d when trying to open up dataset %s\n", dataset_id, dataset_name); 
+    fprintf(stderr, "Error %d when trying to open up dataset %s\n", dataset_id, dataset_name);
     return dataset_id;
   }
 
   if (datatype == 0)
     H5Dread(dataset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
-  else if (datatype == 1)  
+  else if (datatype == 1)
     H5Dread(dataset_id, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
- 
+
   else if (datatype == 2)
     H5Dread(dataset_id, H5T_NATIVE_LLONG, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
 
 
-  
+
   return EXIT_SUCCESS;
 }

--- a/code/main.c
+++ b/code/main.c
@@ -16,7 +16,8 @@
 
 #include "io/io_save_hdf5.h"
 
-char bufz0[1000];
+#define MAX_BUFZ0_SIZE (3*MAX_STRING_LEN+20)
+char bufz0[MAX_BUFZ0_SIZE]; /* 3 strings + max 19 bytes for a number */
 int exitfail = 1;
 
 struct sigaction saveaction_XCPU;
@@ -111,7 +112,7 @@ int main(int argc, char **argv)
   for(filenr = FirstFile; filenr <= LastFile; filenr++)
 #endif
   {
-    sprintf(bufz0, "%s/%s.%d%s", SimulationDir, TreeName, filenr, TreeExtension);
+    snprintf(bufz0, MAX_BUFZ0_SIZE, "%s/%s.%d%s", SimulationDir, TreeName, filenr, TreeExtension);
     if(!(fd = fopen(bufz0, "r")))
     {
       printf("-- missing tree %s ... skipping\n", bufz0);
@@ -120,7 +121,7 @@ int main(int argc, char **argv)
     else
       fclose(fd);
 
-    sprintf(bufz0, "%s/%s_z%1.3f_%d", OutputDir, FileNameGalaxies, ZZ[ListOutputSnaps[0]], filenr);
+    snprintf(bufz0, MAX_BUFZ0_SIZE, "%s/%s_z%1.3f_%d", OutputDir, FileNameGalaxies, ZZ[ListOutputSnaps[0]], filenr);
     if(stat(bufz0, &filestatus) == 0)
     {
       printf("-- output for tree %s already exists ... skipping\n", bufz0);
@@ -195,5 +196,3 @@ int main(int argc, char **argv)
   exitfail = 0;
   return 0;
 }
-
-

--- a/code/main.c
+++ b/code/main.c
@@ -16,8 +16,8 @@
 
 #include "io/io_save_hdf5.h"
 
-#define MAX_BUFZ0_SIZE (3*MAX_STRING_LEN+20)
-char bufz0[MAX_BUFZ0_SIZE]; /* 3 strings + max 19 bytes for a number */
+#define MAX_BUFZ0_SIZE (3*MAX_STRING_LEN+25)
+char bufz0[MAX_BUFZ0_SIZE+1]; /* 3 strings + max 19 bytes for a number */
 int exitfail = 1;
 
 struct sigaction saveaction_XCPU;
@@ -42,7 +42,7 @@ void myexit(int signum)
 #else
   printf("We're exiting\n\n\n");
 #endif
-	  exit(signum);
+          exit(signum);
 }
 
 
@@ -62,7 +62,7 @@ void bye()
     if(ThisTask == 0 && gotXCPU == 1)
       printf("Received XCPU, exiting. But we'll be back.\n");
 #endif
-	  }
+          }
 }
 
 
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
   ThisNode = malloc(MPI_MAX_PROCESSOR_NAME * sizeof(char));
 
   MPI_Get_processor_name(ThisNode, &nodeNameLen);
-  if (nodeNameLen >= MPI_MAX_PROCESSOR_NAME) 
+  if (nodeNameLen >= MPI_MAX_PROCESSOR_NAME)
   {
     printf("Node name string not long enough!...\n");
     ABORT(0);
@@ -136,17 +136,17 @@ int main(int argc, char **argv)
 
     for(treenr = 0; treenr < Ntrees; treenr++)
     {
-      
-			assert(!gotXCPU);
+
+                        assert(!gotXCPU);
 
       if(treenr % 10000 == 0)
       {
 #ifdef MPI
         printf("\ttask: %d\tnode: %s\tfile: %i\ttree: %i of %i\n", ThisTask, ThisNode, filenr, treenr, Ntrees);
 #else
-				printf("\tfile: %i\ttree: %i of %i\n", filenr, treenr, Ntrees);
+                                printf("\tfile: %i\ttree: %i of %i\n", filenr, treenr, Ntrees);
 #endif
-				fflush(stdout);
+                                fflush(stdout);
       }
 
       TreeID = treenr;
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
     if (ThisTask == 0)
 #endif
       //write_master_file();
-  
+
   }
 */
 
@@ -189,9 +189,9 @@ int main(int argc, char **argv)
   //free Ages. But first
   //reset Age to the actual allocated address
   Age--;
-  myfree(Age);                              
+  myfree(Age);
 
-  gsl_rng_free(random_generator); 
+  gsl_rng_free(random_generator);
 
   exitfail = 0;
   return 0;

--- a/code/model_infall.c
+++ b/code/model_infall.c
@@ -7,7 +7,7 @@
 #include "core_allvars.h"
 #include "core_proto.h"
 
-
+#define UNUSED(foo) (void)(foo)
 
 double infall_recipe(int centralgal, int ngal, double Zcurr)
 {
@@ -58,6 +58,7 @@ double infall_recipe(int centralgal, int ngal, double Zcurr)
   infallingMass =
     reionization_modifier * BaryonFrac * Gal[centralgal].Mvir - (tot_stellarMass + tot_coldMass + tot_hotMass + tot_ejected + tot_BHMass + tot_ICS);
     // reionization_modifier * BaryonFrac * Gal[centralgal].deltaMvir - newSatBaryons;
+  UNUSED(newSatBaryons); /* for the moment this is not used */
 
   // the central galaxy keeps all the ejected mass
   Gal[centralgal].EjectedMass = tot_ejected;
@@ -207,4 +208,3 @@ void add_infall_to_hot(int gal, double infallingGas)
   if(Gal[gal].HotGas < 0.0) Gal[gal].HotGas = Gal[gal].MetalsHotGas = 0.0;
 
 }
-


### PR DESCRIPTION
Gcc-10.2.0 gives many compile warnings of the risk of string
buffer overflows. The uncontrolled `sprintf` commands risk segmentation violations if long
path lengths are used, and risk security problems more generally, which is why
the warnings exist.

This commit aims to reduce the chance of buffer overflows by
using `snprintf` instead of `sprintf` and extending from just
the C preprocesor macro MAX_STRING_LEN to extra macros MAX_BUF_SIZE
and MAX_OUTFILE_SIZE, defined e.g. 
as (3*MAX_STRING_LEN+40). A few unused variables are also
commented out in response to the recommendations from gcc.

This commit compiles cleanly for me with gcc-10.2.0, with
`make OPTIONS=-fcommon` to work around Issue https://github.com/darrencroton/sage/issues/16 .
