### PR TITLE
fix: Resolve HDF5 build failures on modern compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,12 @@ else
 endif
 
 ifdef USE-HDF5
-    HDF5DIR := usr/local/x86_64/gnu/hdf5-1.8.17-openmpi-1.10.2-psm
-    HDF5INCL := -I$(HDF5DIR)/include
-    HDF5LIB := -L$(HDF5DIR)/lib -lhdf5 -Xlinker -rpath -Xlinker $(HDF5DIR)/lib
+    # Auto-detect HDF5 via pkg-config, or override: make USE-HDF5=yes HDF5DIR=/path/to/hdf5
+    HDF5DIR    ?= $(shell pkg-config --variable=prefix hdf5_hl 2>/dev/null || \
+                          pkg-config --variable=prefix hdf5 2>/dev/null || \
+                          echo /usr/local)
+    HDF5INCL   := -I$(HDF5DIR)/include
+    HDF5LIB    := -L$(HDF5DIR)/lib -lhdf5_hl -lhdf5 -Xlinker -rpath -Xlinker $(HDF5DIR)/lib
 
     OBJS += ./code/io_tree_hdf5.o ./code/io_save_hdf5.o
     INCL += ./code/io_tree_hdf5.h ./code/io_save_hdf5.h

--- a/code/core_simulation.h
+++ b/code/core_simulation.h
@@ -24,4 +24,4 @@ struct halo_data {
   int FileNr;
   int SubhaloIndex;
   float SubHalfMass;
-} *Halo;
+};

--- a/code/io_save_hdf5.c
+++ b/code/io_save_hdf5.c
@@ -32,6 +32,7 @@
 #include "globals.h"
 #include "io_save_hdf5.h"
 #include "util_error.h"
+#include "util_parameters.h"
 
 #define TRUE 1
 #define FALSE 0
@@ -321,6 +322,7 @@ void prep_hdf5_file(char *fname) {
 
   // Close the HDF5 file.
   status = H5Fclose(file_id);
+  (void)status;
 }
 
 /**
@@ -372,6 +374,7 @@ void write_hdf5_galaxy(struct GALAXY_OUTPUT *galaxy_output, int n, int filenr) {
 
   // Close the file.
   status = H5Fclose(file_id);
+  (void)status;
 }
 
 #ifdef MINIMIZE_IO
@@ -492,6 +495,7 @@ void write_hdf5_attrs(int n, int filenr) {
 
   // Close the file.
   status = H5Fclose(file_id);
+  (void)status;
 }
 
 /**
@@ -617,6 +621,7 @@ static void store_run_properties(hid_t master_file_id) {
   /* Clean up */
   status = H5Sclose(dataspace_id);
   status = H5Gclose(props_group_id);
+  (void)status;
 }
 
 void write_master_file(void) {
@@ -747,6 +752,7 @@ void write_master_file(void) {
 
   // Close the master file.
   H5Fclose(master_file_id);
+  (void)status;
 }
 
 void free_hdf5_ids(void) {

--- a/code/io_tree_hdf5.c
+++ b/code/io_tree_hdf5.c
@@ -205,8 +205,8 @@ void load_tree_hdf5(int32_t filenr, int32_t treenr) {
     char err_msg[MAX_STRING_LEN + 1];
     snprintf(err_msg, MAX_STRING_LEN,
              "The HDF5 file should still be opened when reading the halos in "
-             "tree %d. Error code: %d",
-             treenr, hdf5_file);
+             "tree %d. Error code: %lld",
+             treenr, (long long)hdf5_file);
     fprintf(stderr, "%s\n", err_msg);
     ABORT(0);
   }


### PR DESCRIPTION
## Summary

Addresses the build failures reported in PR #23 with corrections to the Makefile approach.

- **Makefile**: Replace the broken hardcoded HDF5 path with `pkg-config` auto-detection. Uses `pkg-config --variable=prefix hdf5_hl` (falling back to `hdf5`, then `/usr/local`) so any standard installation is found without editing the Makefile. Adds `-lhdf5_hl` which is required for the High-Level Table API (`H5TBmake_table`, `H5TBappend_records`). `HDF5DIR` can still be overridden: `make USE-HDF5=yes HDF5DIR=/custom/path`. `USE-HDF5` remains opt-in (commented out) and `CC` remains `cc`.

- **`core_simulation.h`**: Remove `*Halo` from the struct tail. The pattern `} *Halo;` creates a tentative definition in every translation unit that includes the header, causing duplicate symbol errors on strict linkers (Apple ld). `Halo` is already properly declared `extern` in `globals.h` and defined once in `core_allvars.c`.

- **`io_save_hdf5.c`**: Add missing `#include "util_parameters.h"`. The `store_run_properties()` function uses `ParameterDefinition`, `get_parameter_table()`, and `get_parameter_table_size()` which are declared there. Also fix five pre-existing `-Wunused-but-set-variable` warnings on `status` variables in functions that intentionally discard HDF5 cleanup return values.

- **`io_tree_hdf5.c`**: Fix `%d` format specifier for `hid_t`, which is `long long` on HDF5 ≥ 1.10.

## Test plan

- [ ] `make USE-HDF5=yes` — clean build, zero warnings
- [ ] `make` (no HDF5) — still builds cleanly, `USE-HDF5` opt-in unchanged
- [ ] `make USE-HDF5=yes HDF5DIR=/custom/path` — manual override works

Supersedes PR #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)